### PR TITLE
fix: Button role with Box

### DIFF
--- a/packages/box/src/component.tsx
+++ b/packages/box/src/component.tsx
@@ -14,7 +14,6 @@ const setup = ({
 }: any) => ({
     ...attrs,
     tabIndex: clickable ? 0 : undefined,
-    role: clickable ? 'button' : undefined,
     className: classNames(
         box.box,
         {
@@ -34,5 +33,10 @@ const setup = ({
 export function Box(props: BoxProps) {
     const { children, as = 'div', ...rest } = props;
     const attrs = setup(rest);
-    return React.createElement(as, attrs, children);
+    return React.createElement(as, attrs, props.clickable ? (
+        <>
+            <div>{ children }</div>
+            <span role="button" aria-label="Les mer"></span>
+        </>
+    ) : children);
 }

--- a/packages/box/src/component.tsx
+++ b/packages/box/src/component.tsx
@@ -14,11 +14,14 @@ const setup = ({
 }: any) => ({
     ...attrs,
     tabIndex: clickable ? 0 : undefined,
-    onKeyDown: (event) => {
+    onKeyDown: clickable ? (event) => {
+        // Manually mapping Enter and Space keydown events to the click event (if there is one).
+        // The browser doesn't do this automatically unless the element is a button or an a-element.
+        // The Box element can't be a button or link in case someone puts an interactive element inside the box, which would result in invalid HTML and severe a11y issues.
         if (typeof attrs.onClick === 'function' && (event.keyCode === 13 || event.keyCode === 32)) {
-            attrs.onClick();
+            attrs.onClick(event);
         }
-    },
+    } : undefined,
     className: classNames(
         box.box,
         {

--- a/packages/box/src/component.tsx
+++ b/packages/box/src/component.tsx
@@ -14,6 +14,11 @@ const setup = ({
 }: any) => ({
     ...attrs,
     tabIndex: clickable ? 0 : undefined,
+    onKeyDown: (event) => {
+        if (typeof attrs.onClick === 'function' && (event.keyCode === 13 || event.keyCode === 32)) {
+            attrs.onClick();
+        }
+    },
     className: classNames(
         box.box,
         {

--- a/packages/box/stories/Box.stories.tsx
+++ b/packages/box/stories/Box.stories.tsx
@@ -35,7 +35,11 @@ export const Neutral = () => (
 );
 
 export const Clickable = () => (
-    <Box info clickable>
+    <Box
+        info
+        clickable
+        onClick={() => alert(`You clicked me!`)}
+    >
         <h1>Hover over me, i'm clickable</h1>
     </Box>
 );


### PR DESCRIPTION
Move the button role from the Box element to a separate child element to prevent a11y issues when children of the Box are block elements, interactive elements, or some other type of descendants that would be invalid inside a button.

This feels kind of hacky, and I'm open to other suggestions and solutions.