### PR TITLE
fix(steps): Expose states to screen readers

### DIFF
--- a/packages/steps/src/step.tsx
+++ b/packages/steps/src/step.tsx
@@ -30,7 +30,6 @@ export function Step({ active, completed, children }: StepProps) {
 
     return (
         <div
-            aria-current={active ? 'step' : undefined}
             className={classNames({
                 'f-step': true,
                 [c.stepVertical]: vertical,
@@ -64,7 +63,8 @@ export function Step({ active, completed, children }: StepProps) {
             >
                 <svg
                     role="img"
-                    aria-label="✓"
+                    aria-label={completed ? '✓' : '⍻'}
+                    aria-current={active ? 'step' : undefined}
                     xmlns="http://www.w3.org/2000/svg"
                     width="16"
                     height="16"


### PR DESCRIPTION
I also moved aria-current to the SVG with the checkmark because it can be a little bit too much to hear "Current step" for every piece of content within the currently active step. Now it will only say it once, when the user reads the checkmark (the SVG element).