### PR TITLE
fix(toggle): A11y issues

### DIFF
--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -58,8 +58,8 @@ export function Toggle(props: ToggleProps) {
             )}
             <div
                 className={classNames({
-                    'flex flex-row': props.type === 'radio-button',
-                    'segment-control-options': props.type === 'radio-button',
+                    'flex flex-row segment-control-options':
+                        props.type === 'radio-button',
                 })}
             >
                 {!props.options && props.label ? (

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -42,11 +42,10 @@ export function Toggle(props: ToggleProps) {
         <fieldset
             role={isRadioGroup ? 'radiogroup' : undefined}
             aria-invalid={isRadioGroup ? isInvalid : undefined}
-            aria-errormessage={
-                isRadioGroup && isInvalid ? helpId : undefined
-            }
+            aria-errormessage={isRadioGroup && isInvalid ? helpId : undefined}
             aria-describedby={helpId}
             className={classNames(props.className, {
+                'flex-col': true,
                 'segment-control': props.type === 'radio-button',
                 'segment-control--justified': props.equalWidth,
                 'segment-control--small': props.small,
@@ -57,40 +56,47 @@ export function Toggle(props: ToggleProps) {
             {props.title && (
                 <Title id={id} title={props.title} isInvalid={isInvalid} />
             )}
-            {!props.options && props.label ? (
-                <Item
-                    controlled={isControlled}
-                    label={props.label}
-                    checked={props.checked}
-                    defaultChecked={props.defaultChecked}
-                    onChange={(e: boolean) => props.onChange(e)}
-                    name={`${id}:toggle`}
-                    key={`${id + props.type}`}
-                    invalid={isInvalid}
-                    helpId={helpId}
-                    type={isRadioGroup ? 'radio' : 'checkbox'}
-                />
-            ) : (
-                props.options &&
-                props.options.map((option, i) => (
+            <div
+                className={classNames({
+                    'flex flex-row': props.type === 'radio-button',
+                    'segment-control-options': props.type === 'radio-button',
+                })}
+            >
+                {!props.options && props.label ? (
                     <Item
                         controlled={isControlled}
-                        checked={props.selected?.some(
-                            (s) => s.value === option.value,
-                        )}
-                        defaultChecked={props.defaultSelected?.some(
-                            (s) => s.value === option.value,
-                        )}
-                        option={option}
-                        onChange={(e: ToggleEntry) => props.onChange(e)}
+                        label={props.label}
+                        checked={props.checked}
+                        defaultChecked={props.defaultChecked}
+                        onChange={(e: boolean) => props.onChange(e)}
                         name={`${id}:toggle`}
-                        key={`${id + i + props.type}`}
+                        key={`${id + props.type}`}
                         invalid={isInvalid}
                         helpId={helpId}
                         type={isRadioGroup ? 'radio' : 'checkbox'}
                     />
-                ))
-            )}
+                ) : (
+                    props.options &&
+                    props.options.map((option, i) => (
+                        <Item
+                            controlled={isControlled}
+                            checked={props.selected?.some(
+                                (s) => s.value === option.value,
+                            )}
+                            defaultChecked={props.defaultSelected?.some(
+                                (s) => s.value === option.value,
+                            )}
+                            option={option}
+                            onChange={(e: ToggleEntry) => props.onChange(e)}
+                            name={`${id}:toggle`}
+                            key={`${id + i + props.type}`}
+                            invalid={isInvalid}
+                            helpId={helpId}
+                            type={isRadioGroup ? 'radio' : 'checkbox'}
+                        />
+                    ))
+                )}
+            </div>
 
             {props.helpText && (
                 <HelpText

--- a/packages/toggle/src/component.tsx
+++ b/packages/toggle/src/component.tsx
@@ -39,80 +39,66 @@ export function Toggle(props: ToggleProps) {
     const isControlled = !!props.selected || !!props.checked;
 
     return (
-        <>
-            {props.type === 'radio-button' && props.title && (
+        <fieldset
+            role={isRadioGroup ? 'radiogroup' : undefined}
+            aria-invalid={isRadioGroup ? isInvalid : undefined}
+            aria-errormessage={
+                isRadioGroup && isInvalid ? helpId : undefined
+            }
+            aria-describedby={helpId}
+            className={classNames(props.className, {
+                'segment-control': props.type === 'radio-button',
+                'segment-control--justified': props.equalWidth,
+                'segment-control--small': props.small,
+                'input-toggle':
+                    props.type === 'radio' || props.type === 'checkbox',
+            })}
+        >
+            {props.title && (
                 <Title id={id} title={props.title} isInvalid={isInvalid} />
             )}
-            <fieldset
-                role={isRadioGroup ? 'radiogroup' : undefined}
-                aria-invalid={isRadioGroup ? isInvalid : undefined}
-                aria-errormessage={
-                    isRadioGroup && isInvalid ? helpId : undefined
-                }
-                aria-describedby={
-                    isRadioGroup && !isInvalid ? helpId : undefined
-                }
-                className={classNames(props.className, {
-                    'segment-control': props.type === 'radio-button',
-                    'segment-control--justified': props.equalWidth,
-                    'segment-control--small': props.small,
-                    'input-toggle':
-                        props.type === 'radio' || props.type === 'checkbox',
-                })}
-            >
-                {props.type !== 'radio-button' && props.title && (
-                    <Title id={id} title={props.title} isInvalid={isInvalid} />
-                )}
-                {!props.options && props.label ? (
+            {!props.options && props.label ? (
+                <Item
+                    controlled={isControlled}
+                    label={props.label}
+                    checked={props.checked}
+                    defaultChecked={props.defaultChecked}
+                    onChange={(e: boolean) => props.onChange(e)}
+                    name={`${id}:toggle`}
+                    key={`${id + props.type}`}
+                    invalid={isInvalid}
+                    helpId={helpId}
+                    type={isRadioGroup ? 'radio' : 'checkbox'}
+                />
+            ) : (
+                props.options &&
+                props.options.map((option, i) => (
                     <Item
                         controlled={isControlled}
-                        label={props.label}
-                        checked={props.checked}
-                        defaultChecked={props.defaultChecked}
-                        onChange={(e: boolean) => props.onChange(e)}
+                        checked={props.selected?.some(
+                            (s) => s.value === option.value,
+                        )}
+                        defaultChecked={props.defaultSelected?.some(
+                            (s) => s.value === option.value,
+                        )}
+                        option={option}
+                        onChange={(e: ToggleEntry) => props.onChange(e)}
                         name={`${id}:toggle`}
-                        key={`${id + props.type}`}
+                        key={`${id + i + props.type}`}
                         invalid={isInvalid}
                         helpId={helpId}
                         type={isRadioGroup ? 'radio' : 'checkbox'}
                     />
-                ) : (
-                    props.options &&
-                    props.options.map((option, i) => (
-                        <Item
-                            controlled={isControlled}
-                            checked={props.selected?.some(
-                                (s) => s.value === option.value,
-                            )}
-                            defaultChecked={props.defaultSelected?.some(
-                                (s) => s.value === option.value,
-                            )}
-                            option={option}
-                            onChange={(e: ToggleEntry) => props.onChange(e)}
-                            name={`${id}:toggle`}
-                            key={`${id + i + props.type}`}
-                            invalid={isInvalid}
-                            helpId={helpId}
-                            type={isRadioGroup ? 'radio' : 'checkbox'}
-                        />
-                    ))
-                )}
+                ))
+            )}
 
-                {props.type !== 'radio-button' && props.helpText && (
-                    <HelpText
-                        helpId={helpId}
-                        helpText={props.helpText}
-                        isInvalid={isInvalid}
-                    />
-                )}
-            </fieldset>
-            {props.type === 'radio-button' && props.helpText && (
+            {props.helpText && (
                 <HelpText
                     helpId={helpId}
                     helpText={props.helpText}
                     isInvalid={isInvalid}
                 />
             )}
-        </>
+        </fieldset>
     );
 }

--- a/packages/toggle/src/item.tsx
+++ b/packages/toggle/src/item.tsx
@@ -32,7 +32,7 @@ export function Item({
                 checked={controlled ? checked : undefined}
                 defaultChecked={defaultChecked}
                 aria-invalid={invalid}
-                aria-errormessage={helpId}
+                aria-errormessage={invalid ? helpId : undefined}
                 {...props}
                 onChange={(e) =>
                     props.onChange(

--- a/packages/toggle/stories/Checkbox.stories.tsx
+++ b/packages/toggle/stories/Checkbox.stories.tsx
@@ -42,6 +42,17 @@ export const SingleOptionCheckedUncontrolledDefault = () => {
     );
 };
 
+export const SingleOptionHelpText = () => {
+    return (
+        <Toggle
+            type="checkbox"
+            label="Apple"
+            helpText="This is helper text"
+            onChange={(selected) => console.log(selected)}
+        />
+    );
+};
+
 export const MultipleOptions = () => {
     return (
         <Toggle

--- a/packages/toggle/stories/RadioButtons.stories.tsx
+++ b/packages/toggle/stories/RadioButtons.stories.tsx
@@ -98,6 +98,7 @@ export const SelectedDefaultUncontrolled = () => {
             type="radio-button"
             title="Favorite color"
             helpText="Last selected by default"
+            defaultSelected={[options[options.length - 1]]}
             options={options}
             onChange={(selected) => console.log(selected)}
         />


### PR DESCRIPTION
- No legend element outside fieldset element.
- Same semantics for type "radio" and "radio-button".
- Always set aria-describedby if helper text is available.
- Don't set aria-errormessage on input element if it's not invalid.
- Add single option help text story.